### PR TITLE
Add OAuth2 support

### DIFF
--- a/Botterino/config.py
+++ b/Botterino/config.py
@@ -3,6 +3,33 @@ import os
 import sys
 from . import botfiles, correctMessage, incorrectMessage
 from sty import fg
+import random
+import webbrowser
+import socket
+from prawcore import exceptions
+
+
+def receive_connection():
+    """
+    Wait for and then return a connected socket..
+    Opens a TCP connection on port 8080, and waits for a single client.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(('localhost', 8080))
+    server.listen(1)
+    client = server.accept()[0]
+    server.close()
+    return client
+
+
+def send_message(client, message):
+    """
+    Send message to client and close the connection.
+    """
+    client.send('HTTP/1.1 200 OK\r\n\r\n{}'.format(message).encode('utf-8'))
+    client.close()
+
 
 if sys.platform == 'win32':
     os.system('color')
@@ -15,6 +42,38 @@ try:
     os.chdir(botfiles.botconfig)
     reddit = praw.Reddit('botterino')
     print(f'{fg.green}Successfully logged into reddit as {reddit.user.me()}')
+except exceptions.OAuthException:
+    try:
+        os.chdir(botfiles.botconfig)
+        reddit = praw.Reddit(
+            'botterino', redirect_uri='http://localhost:8080')
+        state = str(random.randint(0, 65000))
+        scopes = ['identity', 'history', 'read',
+                  'edit', 'submit', 'privatemessages']
+        url = reddit.auth.url(scopes, state, 'permanent')
+        print(
+            'A window will be opened in the browser to complete the login process to reddit.')
+        webbrowser.open(url)
+
+        client = receive_connection()
+        data = client.recv(1024).decode('utf-8')
+        param_tokens = data.split(' ', 2)[1].split('?', 1)[1].split('&')
+        params = {key: value for (key, value) in [token.split('=')
+                                                  for token in param_tokens]}
+
+        if state != params['state']:
+            send_message(client, 'State mismatch. Expected: {} Received: {}'.format(
+                state, params['state']))
+        elif 'error' in params:
+            send_message(client, params['error'])
+
+        refresh_token = reddit.auth.authorize(params["code"])
+        send_message(client, "Refresh token: {}".format(refresh_token))
+
+        print(refresh_token)
+    except Exception as e:
+        print(f'{fg.red}Unable to login to reddit. Please check {botfiles.prawconfig}')
+        print(f'{fg.red}{e}')
 except Exception as e:
     print(f'{fg.red}Unable to login to reddit. Please check {botfiles.prawconfig}')
     print(f'{fg.red}{e}')

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It will reply with 'x' or '+correct' to any comments on your round automatically
     `botterino-config/praw.ini`; see `sample-praw.ini` for an example
     1. Give app any name you choose, such as 'botterino'
     2. Choose 'script' as app type
-    3. Fill in 'redirect URI' with `http://localhost:8080` (This is irrelevant but it's a required field)
+    3. Fill in 'redirect URI' with `http://localhost:8080` (This is irrelevant unless OAuth2 is used,but it's a required field)
     4. Once created, you'll have a 'secret', copy/paste that as `client_secret` in botterino-config/praw.ini
     5. You'll also have a less obvious client id, in the top left under the app name and the words 'personal use script' - copy/paste that into `client_id` in praw.ini
 4. Fill out the rest of 'botterino-config/praw.ini' with your Reddit username/password as well as anything you want for `user_agent`


### PR DESCRIPTION
I added support for reddit accounts with 2FA enabled by adapting the code example from the [praw documentation](https://praw.readthedocs.io/en/latest/tutorials/refresh_token.html). After starting botterino, a browser window will open asking you to allow the connection to the reddit account.

![image](https://user-images.githubusercontent.com/64196842/144895532-5587b19a-de2e-45b4-bd67-6ee37c69e911.png)

After clicking "allow," the refresh token is automatically transferred and the browser window can be closed. Setting the application's `redirect uri` to `localhost:8080` is now required, so I changed the readme accordingly.

Logging in on an account without 2FA remains unchanged. 

These new packages have to be imported: `webbrowser` and `socket` (both included in the python standard library)