### PR TITLE
Re-do hints

### DIFF
--- a/Botterino/Loader/loader.py
+++ b/Botterino/Loader/loader.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from ..config import roundfile, archivefile
+from ..config import roundfile, archivefile, hintfile
 import ruamel.yaml
 
 yaml = ruamel.yaml.YAML()
@@ -40,4 +40,9 @@ def getRound():
     y = load(archivefile) or {}
     y[k] = top
     dump(y, archivefile)
-    return top
+    return k, top
+
+def loadHints(key):
+    with open(hintfile, "r", encoding="utf-8") as f:
+        hints_data = yaml.load(f)
+    return hints_data.get(key, {}).get("hints", [])

--- a/Botterino/__init__.py
+++ b/Botterino/__init__.py
@@ -13,7 +13,7 @@ class files:
         self.rounds = os.path.join(self.roundsdir, "rounds.yaml")
         self.archive = os.path.join(self.roundsdir, "archive.yaml")
         self.prawconfig = os.path.join(self.botconfig, "praw.ini")
-        self.hintfile = os.path.join(self.botconfig, "hints.txt")
+        self.hintfile = os.path.join(self.botconfig, "hints.yaml")
 
 
 botfiles = files()

--- a/Botterino/config.py
+++ b/Botterino/config.py
@@ -37,6 +37,7 @@ if sys.platform == "win32":
 debug = False
 roundfile = botfiles.rounds
 archivefile = botfiles.archive
+hintfile = botfiles.hintfile
 cwd = os.getcwd()
 # FIXME: clean this up
 try:

--- a/Botterino/failure.py
+++ b/Botterino/failure.py
@@ -5,11 +5,11 @@ from .Loader import loader
 from sty import fg
 import time
 
-r = loader.getRound()
+k, r = loader.getRound()
 while not r:
     colormsg(f"No rounds in round file! checking again in 10s", fg.red)
     time.sleep(10)
-    r = loader.getRound()
+    k, r = loader.getRound()
 
 submission = next(iter(pg.new()))
 colormsg(

--- a/README.md
+++ b/README.md
@@ -66,17 +66,8 @@ This is useful for cases where
 
 ### Hints:
 Botterino can schedule hints and post them autmoatically.
-If the file `botterino-config/hints.txt` contains content,
-its content will be posted to the currently hosted round as a hint
-at the time specified by the user, and then the file is cleared.
-Default hint times can be specified
-in `botterino-config/config.ini`.
-The default value is `hints=[25,45]`.
-The default hint list can be overridden per round by adding the field
-`hints: [10, 20,30]` as a new field in rounds.yaml.
-Hint times are in minutes and are integers.
-Hints at hour boundaries do not need to be specified. If the
-hint file contains text it will be posted automatically at 60,120,180 etc...
+The file `botterino-config/hints.yaml` will be scanned for entries with the same key
+as the corresponding entry in `botterino-config/rounds.yaml`. See `sample-hints.yaml` for syntax.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This is useful for cases where
 2. Run with `python -m botterino.failure`
 
 ### Hints:
-Botterino can schedule hints and post them autmoatically.
+Botterino can schedule hints and post them automatically.
 The file `botterino-config/hints.yaml` will be scanned for entries with the same key
 as the corresponding entry in `botterino-config/rounds.yaml`. See `sample-hints.yaml` for syntax.
 

--- a/sample-hints.yaml
+++ b/sample-hints.yaml
@@ -1,0 +1,17 @@
+# hints use yaml syntax
+# indentation must be two spaces
+# use http://www.yamllint.com/ to check your round file syntax! if something is wrong the program will crash!
+
+# hint the round with the key vegas_round from sample-rounds.yaml
+vegas_round:
+  hints:
+    - time: 20
+      text: "This is the first hint for the vegas round."
+    - time: 60
+      text: "This is the first hourly hint for the vegas round."
+    - time: 120
+      text: "This is the second hourly hint for the vegas round."
+    - time: 180
+      text: "This is the third hourly hint for the vegas round."
+    - time: 240
+      text: "This is the fourth hourly hint for the vegas round."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = botterino
-version = 0.5.1
+version = 0.5.2
 author = itoxici
 author_email = itox@picturegame.co
 description = Automate posting and hosting of rounds on /r/picturegame


### PR DESCRIPTION
Hints are now specified in a YAML file. The expected format can be seen in `sample-hints.yaml`. Also, checking whether we're hosting is now done with a `threading.Event` rather than an API call.