### PR TITLE
Re-do `failure.py`

### DIFF
--- a/Botterino/Utils/utils.py
+++ b/Botterino/Utils/utils.py
@@ -122,6 +122,21 @@ def getComments(submission):
                 continue
             yield c
 
+
+def getCurrentComments(submission):
+    submission.comments.replace_more(limit=None)
+    return submission.comments.list()
+
+
+def readExistingHints(submission):
+    existing_hints = []
+    comments = getCurrentComments(submission)
+    for c in comments:
+        if c.author.name.lower() == username.lower() and "Hint" in c.body:
+            existing_hints.append(c.body)
+    return existing_hints
+
+
 def hasHostReplied(comment):
     for reply in comment.replies:
         if reply.author and reply.author.name.lower() == username.lower():

--- a/Botterino/Utils/utils.py
+++ b/Botterino/Utils/utils.py
@@ -121,3 +121,9 @@ def getComments(submission):
             if c.author.name.lower() in donotreply or c.submission != submission:
                 continue
             yield c
+
+def hasHostReplied(comment):
+    for reply in comment.replies:
+        if reply.author and reply.author.name.lower() == username.lower():
+            return True
+    return False

--- a/Botterino/failure.py
+++ b/Botterino/failure.py
@@ -1,7 +1,7 @@
 from .hosterino import checkAnswers, checkHints, checkAnswer
-from .config import pg, correctMessage, incorrectMessage
+from .config import pg, correctMessage, incorrectMessage, username
 from .Utils.color import colormsg
-from .Utils.utils import approved, getComments, hasHostReplied
+from .Utils.utils import approved, getCurrentComments, hasHostReplied
 from .Loader import loader
 from sty import fg
 import time
@@ -29,14 +29,13 @@ def processUnrepliedComments(submission, r):
         r.get("similarity"),
         r.get("ignorecase"),
     )
-    comments = list(getComments(submission))
+    comments = getCurrentComments(submission)
     comments.sort(key=lambda c: datetime.fromtimestamp(c.created_utc))
     for c in comments:
-        if not hasHostReplied(c):
+        if not hasHostReplied(c) and c.author.name.lower() not in ["r-picturegame", username.lower()]:
             if checkAnswer(
                 c,
                 tolerance,
-                manual,
                 text,
                 answer,
                 tolerances,
@@ -63,11 +62,12 @@ def processUnrepliedComments(submission, r):
                 c.reply(incorrectMessage)
 
 
-k, r = loader.getRound()
-while not r:
+round = loader.getRound()
+while not round:
     colormsg(f"No rounds in round file! checking again in 10s", fg.red)
     time.sleep(10)
-    k, r = loader.getRound()
+    round = loader.getRound()
+k, r = round
 
 submission = next(iter(pg.new()))
 colormsg(

--- a/Botterino/failure.py
+++ b/Botterino/failure.py
@@ -6,6 +6,7 @@ from .Loader import loader
 from sty import fg
 import time
 from threading import Thread, Event
+from datetime import datetime
 
 
 def processUnrepliedComments(submission, r):
@@ -28,7 +29,8 @@ def processUnrepliedComments(submission, r):
         r.get("similarity"),
         r.get("ignorecase"),
     )
-    comments = getComments(submission)
+    comments = list(getComments(submission))
+    comments.sort(key=lambda c: datetime.fromtimestamp(c.created_utc))
     for c in comments:
         if not hasHostReplied(c):
             if checkAnswer(

--- a/Botterino/failure.py
+++ b/Botterino/failure.py
@@ -1,9 +1,65 @@
-from .hosterino import checkAnswers
-from .config import pg
+from .hosterino import checkAnswers, checkHints, checkAnswer
+from .config import pg, correctMessage, incorrectMessage
 from .Utils.color import colormsg
+from .Utils.utils import approved, getComments, hasHostReplied
 from .Loader import loader
 from sty import fg
 import time
+from threading import Thread, Event
+
+
+def processUnrepliedComments(submission, r):
+    (
+        tolerance,
+        manual,
+        text,
+        answer,
+        tolerances,
+        answers,
+        similarity,
+        ignorecase,
+    ) = (
+        r.get("tolerance"),
+        r.get("manual"),
+        r.get("text"),
+        r.get("answer"),
+        r.get("tolerances"),
+        r.get("answers"),
+        r.get("similarity"),
+        r.get("ignorecase"),
+    )
+    comments = getComments(submission)
+    for c in comments:
+        if not hasHostReplied(c):
+            if checkAnswer(
+                c,
+                tolerance,
+                manual,
+                text,
+                answer,
+                tolerances,
+                answers,
+                similarity,
+                ignorecase,
+                None,
+            ):
+                colormsg(f"Correct guess found in comment: {c.permalink}", fg.green)
+                if manual:
+                    colormsg(
+                        f"Guess '{c.body}' looks correct, but you will have to check it out.",
+                    )
+                else:
+                    plusCorrect = c.reply(correctMessage)
+                    guesser = c.author.name
+                    colormsg(
+                        f"Corrected {guesser} in {plusCorrect.created_utc - c.created_utc}s",
+                        fg.green,
+                    )
+                    break
+            else:
+                colormsg(f"Incorrect guess in comment: {c.permalink}", fg.red)
+                c.reply(incorrectMessage)
+
 
 k, r = loader.getRound()
 while not r:
@@ -15,7 +71,27 @@ submission = next(iter(pg.new()))
 colormsg(
     f"Checking answers on https://reddit.com{submission.permalink}",
 )
-checkAnswers(r, submission)
+
+# Process unreplied comments
+processUnrepliedComments(submission, r)
+
+# Create an event to signal the round status
+round_active_event = Event()
+round_active_event.set()
+
+CheckAnswers = Thread(target=checkAnswers, args=(r, submission))
+CheckHints = Thread(target=checkHints, args=(k, submission, round_active_event))
+CheckAnswers.start()
+CheckHints.start()
+
+# Wait for threads to finish
+CheckAnswers.join()
+round_active_event.clear()  # Clear the event to signal that the round is over
+CheckHints.join()
+
+while approved():
+    continue
 after = r.get("after")
 if after:
     submission.reply(after)
+    colormsg(f"Posted your message after the round: {after}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = botterino
-version = 0.5.2
+version = 0.5.3
 author = itoxici
 author_email = itox@picturegame.co
 description = Automate posting and hosting of rounds on /r/picturegame


### PR DESCRIPTION
We now support automatic hints while running in `failure` mode. We check the texts of hints which have already been posted in order to ensure that we do not double-post hints if the bot is restarted. We now also automatically check guesses posted before the bot is started in `failure` mode (only replying to comments which have not already been replied to by the host, again to prevent double replies to guesses).

Tested on this round: https://www.reddit.com/r/PictureGame/comments/1ddtyw0/round_136741_please_give_me_the_coordinates_of/