### PR TITLE
bugfixes for hinting

### DIFF
--- a/Botterino/Loader/loader.py
+++ b/Botterino/Loader/loader.py
@@ -45,4 +45,4 @@ def getRound():
 def loadHints(key):
     with open(hintfile, "r", encoding="utf-8") as f:
         hints_data = yaml.load(f)
-    return hints_data.get(key, {}).get("hints", [])
+    return (hints_data or {}).get(key, {}).get("hints", [])

--- a/Botterino/Utils/utils.py
+++ b/Botterino/Utils/utils.py
@@ -124,15 +124,16 @@ def getComments(submission):
 
 
 def getCurrentComments(submission):
-    submission.comments.replace_more(limit=None)
-    return submission.comments.list()
+    refreshed = reddit.submission(submission)
+    refreshed.comments.replace_more(limit=None)
+    return refreshed.comments.list()
 
 
 def readExistingHints(submission):
     existing_hints = []
     comments = getCurrentComments(submission)
     for c in comments:
-        if c.author.name.lower() == username.lower() and "Hint" in c.body:
+        if c.author and c.author.name.lower() == username.lower() and "Hint" in c.body:
             existing_hints.append(c.body)
     return existing_hints
 

--- a/Botterino/failure.py
+++ b/Botterino/failure.py
@@ -32,7 +32,12 @@ def processUnrepliedComments(submission, r):
     comments = getCurrentComments(submission)
     comments.sort(key=lambda c: datetime.fromtimestamp(c.created_utc))
     for c in comments:
-        if not hasHostReplied(c) and c.author.name.lower() not in ["r-picturegame", username.lower()]:
+        if (
+            not hasHostReplied(c)
+            and c.author
+            and c.author.name.lower() not in ["r-picturegame", username.lower()]
+            and c.is_root
+        ):
             if checkAnswer(
                 c,
                 tolerance,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = botterino
-version = 0.5.3
+version = 0.5.4
 author = itoxici
 author_email = itox@picturegame.co
 description = Automate posting and hosting of rounds on /r/picturegame


### PR DESCRIPTION
This addresses an error that occurs when `hints.yaml` exists but is empty. Also, `getCurrentComments` wasn't properly refreshing comments on the submission, which was causing issues when `checkHints` was looking for hints that were already posted.