### PR TITLE
Address rate limiting when checking for hints

### DIFF
--- a/Botterino/hosterino.py
+++ b/Botterino/hosterino.py
@@ -132,13 +132,14 @@ def postHint(submission, time, hintText):
 
 def checkHints(key, submission, round_active_event, poll_interval=30):
     initial = True
+    posted_hints = set()
     while round_active_event.is_set():
         hints = loadHints(key)
         existing_hints = None
 
         for hint in hints:
             duration = int(time.time() - submission.created_utc) // 60
-            if hint["time"] <= duration:
+            if hint["time"] <= duration and (hint["time"], hint["text"]) not in posted_hints:
                 if not existing_hints:
                     existing_hints = readExistingHints(submission)
 
@@ -147,6 +148,7 @@ def checkHints(key, submission, round_active_event, poll_interval=30):
                         colormsg(f"Looks like the hint for time {hint['time']}m is already posted")
                 else:
                     postHint(submission, duration, hint["text"])
+                    posted_hints.add((hint["time"], hint["text"]))
 
         initial = False
         time.sleep(poll_interval)

--- a/Botterino/hosterino.py
+++ b/Botterino/hosterino.py
@@ -131,7 +131,6 @@ def postHint(submission, time, hintText):
 
 
 def checkHints(key, submission, round_active_event, poll_interval=30):
-    initial = True
     posted_hints = set()
     while round_active_event.is_set():
         hints = loadHints(key)
@@ -144,8 +143,8 @@ def checkHints(key, submission, round_active_event, poll_interval=30):
                     existing_hints = readExistingHints(submission)
 
                 if any(hint["text"] in existing_hint for existing_hint in existing_hints):
-                    if initial:
-                        colormsg(f"Looks like the hint for time {hint['time']}m is already posted")
+                    colormsg(f"Looks like the hint for time {hint['time']}m is already posted")
+                    posted_hints.add((hint["time"], hint["text"]))
                 else:
                     postHint(submission, duration, hint["text"])
                     posted_hints.add((hint["time"], hint["text"]))

--- a/Botterino/hosterino.py
+++ b/Botterino/hosterino.py
@@ -134,11 +134,14 @@ def checkHints(key, submission, round_active_event, poll_interval=30):
     initial = True
     while round_active_event.is_set():
         hints = loadHints(key)
-        existing_hints = readExistingHints(submission)
+        existing_hints = None
 
         for hint in hints:
             duration = int(time.time() - submission.created_utc) // 60
             if hint["time"] <= duration:
+                if not existing_hints:
+                    existing_hints = readExistingHints(submission)
+
                 if any(hint["text"] in existing_hint for existing_hint in existing_hints):
                     if initial:
                         colormsg(f"Looks like the hint for time {hint['time']}m is already posted")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = botterino
-version = 0.5.4
+version = 0.5.5
 author = itoxici
 author_email = itox@picturegame.co
 description = Automate posting and hosting of rounds on /r/picturegame


### PR DESCRIPTION
Rather than loading current comments every time we refresh the hints from the hints YAML file, we should only load them when we actually have a new hint (one whose specified time is past and that hasn't been posted yet while the bot is running).