### PR TITLE
Make checkAnswers block until +correct regardless of whether an answer is provided

### DIFF
--- a/Botterino/hosterino.py
+++ b/Botterino/hosterino.py
@@ -218,37 +218,37 @@ def checkAnswers(r, submission):
         except Exception:
             pass
 
-    if tolerance is None and tolerances is None and text is None:
-        return
-
     for c in getComments(submission):
-        result = checkAnswer(
-            c,
-            tolerance,
-            text,
-            answer,
-            tolerances,
-            answers,
-            similarity,
-            ignorecase,
-            answerPlot,
-        )
+        if tolerance or tolerances or text:
+            result = checkAnswer(
+                c,
+                tolerance,
+                text,
+                answer,
+                tolerances,
+                answers,
+                similarity,
+                ignorecase,
+                answerPlot,
+            )
 
-        if not result:
-            c.reply(incorrectMessage)
-        if result:
-            if manual:
-                colormsg(
-                    f"Guess '{c.body}' looks correct, but you will have to check it out.",
-                )
-            else:
-                plusCorrect = c.reply(correctMessage)
-                guesser = c.author.name
-                colormsg(
-                    f"Corrected {guesser} in {plusCorrect.created_utc - c.created_utc}s",
-                    fg.green,
-                )
-                break
+            if not result:
+                c.reply(incorrectMessage)
+            if result:
+                if manual:
+                    colormsg(
+                        f"Guess '{c.body}' looks correct, but you will have to check it out.",
+                    )
+                else:
+                    plusCorrect = c.reply(correctMessage)
+                    guesser = c.author.name
+                    colormsg(
+                        f"Corrected {guesser} in {plusCorrect.created_utc - c.created_utc}s",
+                        fg.green,
+                    )
+                    break
+        else:
+            pass
 
     # TODO: show the map on every guess instead of only when the round is over
     if answerPlot:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = botterino
-version = 0.5.5
+version = 0.5.6
 author = itoxici
 author_email = itox@picturegame.co
 description = Automate posting and hosting of rounds on /r/picturegame


### PR DESCRIPTION
This addresses a 429 error thrown by the Reddit API when we do `approved()` too many times if `checkAnswers` doesn't block in the `main` loop in `botterino.py` (e.g. if no answer is provided for the round in the YAML, but the user still wants botterino to handle hinting). Essentially, we need `checkAnswers` to block until we see a `+correct`, regardless of whether there's an actual answer in the YAML to check or not.